### PR TITLE
Force $operatingsystemmajrelease become a integer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,7 +174,7 @@ class ganesha (
         notify  => Service[$ganesha::params::ganesha_service]
      }
 
-     if ($operatingsystemmajrelease >= 7) {
+     if (($operatingsystemmajrelease + 0) >= 7) {
        file { $ganesha::params::shared_storage_tmpconfig:
           ensure => present,
           owner  => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@ class ganesha::params {
          $ganesha_debuglevel        = "NIV_EVENT"
          $ganesha_pidfile           = "/var/run/ganesha.pid"
          $rquota_port               = 875
-         if ($operatingsystem != 'Fedora' and $operatingsystemmajrelease < 7) {
+         if ($operatingsystem != 'Fedora' and ($operatingsystemmajrelease + 0) < 7) {
            $shared_storage_mountpoint = '/var/run/gluster/shared_storage'
          } else {
            $shared_storage_mountpoint = '/run/gluster/shared_storage'


### PR DESCRIPTION
When I run in a Cientos 7 machine I get the next error:

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Comparison of: String < Integer, is not possible. Caused by 'A String is not comparable to a non String'. at /etc/puppetlabs/code/environments/production/modules_external/ganesha/manifests/params.pp:18:74 on node XXXXXXX

I understand the facter $operatingsystemmajrelease return a String and you are comparating with a integer.
I propose you convert the facter in a integer to do well the comparation. If in other OS the facter is already a integer will be untouched.