### PR TITLE
Changes needed to exports.conf.erb

### DIFF
--- a/templates/export.conf.erb
+++ b/templates/export.conf.erb
@@ -1,22 +1,22 @@
-<% exports.each do |expid,export| -%>
+<% @exports.each do |expid,export| -%>
 EXPORT{
 	Export_Id = <%= expid %>;
-	Path = "<%= @export['path'] %>";
+	Path = "<%= export['path'] %>";
 
 	FSAL { 
 		name = GLUSTER;
 <% if export['hostname'] -%>
-		hostname = "<%= @export['hostname'] %>";
+		hostname = "<%= export['hostname'] %>";
 <% else -%>
-		hostname = "<%= @fqdn %>";
+		hostname = "<%= fqdn %>";
 <% end -%>
-		volume = "<%= @export['volume'] %>";
+		volume = "<%= export['volume'] %>";
 	}
 
 	Access_type = RW;
 	Squash = No_root_squash;
 	Disable_ACL = TRUE;
-	Pseudo = "<%= @export['pseudo_path'] %>";
+	Pseudo = "<%= export['pseudo_path'] %>";
 	Protocols = "3,4";
 	Transports = "UDP,TCP";
 	SecType = "sys";


### PR DESCRIPTION
I needed to edit export.conf.erb to change the initial loop from exports.each ……to @exports.each and removing the @ from the various export elements to resolve an error creating a ganesha export

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: {"message":"Server Error: Evaluation Error: Error while evaluating a Function Call, Failed to parse template ganesha/export.conf.erb:\n  Filepath: /etc/puppetlabs/code/environments/production/modules/ganesha/templates/export.conf.erb\n  Line: 1\n  Detail: undefined local variable or method `exports' for #<Puppet::Parser::TemplateWrapper:0x6ddce79f>\n at /etc/puppetlabs/code/environments/production/modules/ganesha/manifests/init.pp:148:20 on node gl1.cs.man.ac.uk","issue_kind":"RUNTIME_ERROR","stacktrace":["Warning: The 'stacktrace' property is deprecated and will be removed in a future version of Puppet. For security reasons, stacktraces are not returned with Puppet HTTP Error responses."]}


Hope this is acceptable to you?

-- Sean
